### PR TITLE
Сделать все поля модели Movie необязательными

### DIFF
--- a/kinopoisk_dev/model.py
+++ b/kinopoisk_dev/model.py
@@ -183,12 +183,12 @@ class VendorImage(BaseModel):
 
 
 class Movie(BaseModel):
-    id: int = Field(..., description="Id фильма с кинопоиска", example=666)
-    externalId: ExternalId
+    id: Optional[int] = Field(..., description="Id фильма с кинопоиска", example=666)
+    externalId: Optional[ExternalId]
     name: Optional[str] = Field(example="Человек паук")
     alternativeName: Optional[str] = Field(example="Spider man")
-    names: List[Name]
-    type: str = Field(
+    names: Optional[List[Name]]
+    type: Optional[str] = Field(
         description="Тип тайтла. Доступны: movie | tv-series | cartoon | anime | animated-series | tv-show",
         example="movie",
     )


### PR DESCRIPTION
При запросе к API с помощью параметра `selectFields` я могу указать поля, которые хочу получить. Раньше мне было необходимо указывать поля id, externalId, names и type даже если они мне не нужны.

Я использую API для получения слоганов фильмов по их imdb_id:

Request:
```
curl -X 'GET' \
  'https://api.kinopoisk.dev/v1.3/movie?selectFields=slogan&page=1&limit=10&externalId.imdb=tt0232500' \
  -H 'accept: application/json' \
  -H 'X-API-KEY: Token'
```

Response:
```
{
  "docs": [
    {
      "slogan": "Если у тебя есть то, что нужно... ты можешь получить всё"
    }
  ],
  "total": 1,
  "limit": 10,
  "page": 1,
  "pages": 1
}
```

Теперь такой запрос будет работать корректно